### PR TITLE
Clean up settings page.

### DIFF
--- a/src/coffee/settings/settings.styl
+++ b/src/coffee/settings/settings.styl
@@ -31,11 +31,14 @@ pt-settings-container
 
   .settings-panel
     margin-bottom: 25px
+    margin-left: auto
+    margin-right: auto
+    width: 65%
 
     .settings-panel-header
       padding: 10px 20px
       border-bottom: 1px solid $table-border-color
-      font-size: 14px
+      font-size: 22px
       font-weight: 500
       color: #fff
       border-top-left-radius: 3px

--- a/src/coffee/settings/templates/settings-buttons.html
+++ b/src/coffee/settings/templates/settings-buttons.html
@@ -1,6 +1,6 @@
 <section class="buttons" layout="row" layout-sm="column" layout-align="center center">
-    <md-button class="md-raised" ng-if="settings.config.showAdvancedSettings">Flush bookmarks database</md-button>
-    <md-button class="md-raised" ng-if="settings.config.showAdvancedSettings">Flush subtitles cache</md-button>
+    <md-button class="md-raised md-accent" ng-if="settings.config.showAdvancedSettings">Flush bookmarks database</md-button>
+    <md-button class="md-raised md-accent" ng-if="settings.config.showAdvancedSettings">Flush subtitles cache</md-button>
     <md-button class="md-raised md-accent">Flush all databases</md-button>
     <md-button class="md-raised md-accent">Reset to Default Settings</md-button>
 </section>

--- a/src/coffee/settings/templates/settings-database.html
+++ b/src/coffee/settings/templates/settings-database.html
@@ -13,12 +13,12 @@
         <md-input-container>
             <input type="file" name="fakedatabaseLocation" id="fakedatabaseLocation" nwdirectory style="display: none;" nwworkingdir="{{ settings.config.databaseLocation }}" />
         </md-input-container>
-        
+
         <div class="btns advanced database">
-             <md-button class="md-primary md-raised" type="button">
+             <md-button class="md-primary md-raised md-accent" type="button">
                 Import Database
             </md-button>
-            <md-button class="md-primary md-raised" type="button">
+            <md-button class="md-primary md-raised md-accent" type="button">
                 Export Database
             </md-button>
         </div>

--- a/src/coffee/settings/templates/settings-miscellaneous.html
+++ b/src/coffee/settings/templates/settings-miscellaneous.html
@@ -2,31 +2,30 @@
     <div class="settings-panel-header">
         Miscellaneous
     </div>
-    
+
     <div class="settings-panel-body">
         <section class="settings-select">
-            <div class="select-label">Miscellaneous</div>
+            <div class="select-label">When Opening TV Series Detail Jump To</div>
             <md-select class="settings-dropdown" ng-model="settings.config.jump_to">
                 <md-option ng-repeat="jump_to in settings.tv_detail_jump_to" name="jump_to">{{ jump_to }}</md-option>
             </md-select>
-            <p>When Opening TV Series Detail Jump To</p>
         </section>
 
         <md-input-container>
             <label>Activate automatic updating</label>
             <md-checkbox ng-model="settings.config.automaticUpdating"></md-checkbox>
         </md-input-container>
-        
+
         <md-input-container>
             <label>Celebrate various events</label>
             <md-checkbox ng-model="settings.config.events"></md-checkbox>
         </md-input-container>
-        
+
         <md-input-container>
             <label>Minimize to Tray</label>
             <md-checkbox ng-model="settings.config.minimizeToTray"></md-checkbox>
         </md-input-container>
-        
+
         <md-input-container>
             <label>Big Picture Mode</label>
             <md-checkbox ng-model="settings.config.bigPicture"></md-checkbox>

--- a/src/coffee/settings/templates/settings-miscellaneous.html
+++ b/src/coffee/settings/templates/settings-miscellaneous.html
@@ -12,23 +12,27 @@
         </section>
 
         <md-input-container>
-            <label>Activate automatic updating</label>
-            <md-checkbox ng-model="settings.config.automaticUpdating"></md-checkbox>
+            <md-checkbox ng-model="settings.config.automaticUpdating">
+                Activate automatic updating
+            </md-checkbox>
         </md-input-container>
 
         <md-input-container>
-            <label>Celebrate various events</label>
-            <md-checkbox ng-model="settings.config.events"></md-checkbox>
+            <md-checkbox ng-model="settings.config.events">
+                Celebrate various events
+            </md-checkbox>
         </md-input-container>
 
         <md-input-container>
-            <label>Minimize to Tray</label>
-            <md-checkbox ng-model="settings.config.minimizeToTray"></md-checkbox>
+            <md-checkbox ng-model="settings.config.minimizeToTray">
+                Minimize to Tray
+            </md-checkbox>
         </md-input-container>
 
         <md-input-container>
-            <label>Big Picture Mode</label>
-            <md-checkbox ng-model="settings.config.bigPicture"></md-checkbox>
+            <md-checkbox ng-model="settings.config.bigPicture">
+                Big Picture Mode
+            </md-checkbox>
         </md-input-container>
     </div>
 </section>

--- a/src/coffee/settings/templates/settings-playback.html
+++ b/src/coffee/settings/templates/settings-playback.html
@@ -5,14 +5,15 @@
 
     <div class="settings-panel-body">
         <md-input-container ng-if="settings.config.showAdvancedSettings">
-            <label>Always start playing in fullscreen</label>
-            <md-checkbox aria-label="start-fullscreen" ng-model="settings.config.alwaysFullscreen"></md-checkbox>
+            <md-checkbox aria-label="start-fullscreen" ng-model="settings.config.alwaysFullscreen">
+                Always start playing in fullscreen
+            </md-checkbox>
         </md-input-container>
 
         <md-input-container>
-            <label>Play next episode automatically</label>
-            <md-checkbox aria-label="play-next-episode"
-                         ng-model="settings.config.playNextEpisodeAuto"></md-checkbox>
+            <md-checkbox aria-label="play-next-episode" ng-model="settings.config.playNextEpisodeAuto">
+                Play next episode automatically
+            </md-checkbox>
         </md-input-container>
 
     </div>

--- a/src/coffee/settings/templates/settings-quality.html
+++ b/src/coffee/settings/templates/settings-quality.html
@@ -5,13 +5,13 @@
 
     <div class="settings-panel-body">
         <section class="settings-select">
+            <div class="select-label">Only list movies in</div>
             <md-select class="settings-dropdown" ng-model="settings.config.movies_quality"
                        name="movies_quality" aria-label="Show by quality">
                 <md-option value="all">All</md-option>
                 <md-option value="1080p">1080p</md-option>
                 <md-option value="720p">720p</md-option>
             </md-select>
-            <p>Only list movies in</p>
         </section>
 
         <md-input-container>

--- a/src/coffee/settings/templates/settings-quality.html
+++ b/src/coffee/settings/templates/settings-quality.html
@@ -15,8 +15,10 @@
         </section>
 
         <md-input-container>
-            <label>Show movie quality on list</label>
-            <md-checkbox aria-label="show-quality" ng-model="settings.config.moviesShowQuality"></md-checkbox>
+            <label></label>
+            <md-checkbox aria-label="show-quality" ng-model="settings.config.moviesShowQuality">
+                Show movie quality on list
+            </md-checkbox>
         </md-input-container>
 
     </div>

--- a/src/coffee/settings/templates/settings-subtitles.html
+++ b/src/coffee/settings/templates/settings-subtitles.html
@@ -6,38 +6,39 @@
     <div class="settings-panel-body">
 
         <section class="settings-select">
+            <div class="select-label">Default Subtitle</div>
             <md-select class="settings-dropdown" aria-label="default-subtitle"
                        ng-model="settings.config.sub_lang">
                <md-option ng-repeat="lang in settings.config.sub_langs" name="subtitle_language">{{ lang }}</md-option>
             </md-select>
-            <p>Default Subtitle</p>
         </section>
 
         <section class="settings-select" ng-if="settings.config.showAdvancedSettings">
+            <div class="select-label">Font</div>
             <md-select class="settings-dropdown" aria-label="font-subtitle" ng-model="settings.config.sub_font">
                <md-option ng-repeat="font in settings.sub_fonts" name="sub_fonts">{{ font }}</md-option>
             </md-select>
-            <p>Font</p>
         </section>
 
         <section class="settings-select" ng-if="settings.config.showAdvancedSettings">
+            <div class="select-label">Decoration</div>
             <md-select class="settings-dropdown" aria-label="decoration-subtitle"
                        ng-model="settings.config.sub_deco">
                 <md-option ng-repeat="deco in settings.sub_deco" name="sub_deco">{{ deco }}</md-option>
             </md-select>
-            <p>Decoration</p>
         </section>
 
         <section class="settings-select">
+            <div class="select-label">Size</div>
             <md-select class="settings-dropdown" aria-label="size-subtitle"
                        ng-model="settings.config.sub_size">
                 <md-option ng-repeat="size in settings.sub_sizes" name="sub_size">{{ size }}</md-option>
             </md-select>
-            <p>Size</p>
         </section>
 
         <section class="settings-select" ng-if="settings.config.showAdvancedSettings">
             <div class="subtitles-custom">
+                <div class="select-label">Color</div>
                 <input class="colorsub" aria-label="color-subtitle" id="subtitles_color"
                        type="color" size="7" name="subtitle_color"
                        ng-model="settings.config.subtitle_color" list="subs_colors">
@@ -50,7 +51,6 @@
                     <option>#00ff00</option>
                 </datalist>
             </div>
-            <p>Color</p>
         </section>
     </div>
 </section>

--- a/src/coffee/settings/templates/settings-trakttv.html
+++ b/src/coffee/settings/templates/settings-trakttv.html
@@ -34,7 +34,7 @@
                 </section>
 
                 <section class="settings-select">
-                    <md-button ng-click="connectTrakt()">
+                    <md-button class="md-raised md-accent" ng-click="connectTrakt()">
                         <md-icon md-font-set="material-icons">user</md-icon>
                         Connect To Trakt
                     </md-button>

--- a/src/coffee/settings/templates/settings-trakttv.html
+++ b/src/coffee/settings/templates/settings-trakttv.html
@@ -8,7 +8,7 @@
                 <section class="settings-select" ng-if="app.Trakt.authenticated">
                     You are currently connected to Trakt.tv.
                     <a id="unauthTrakt" class="unauthtext" href="#">Disconnect account</a>
-                </section>>
+                </section>
 
                 <md-input-container>
                     <md-checkbox aria-label="Automatically Sync on Start" ng-model="settings.config.traktSyncOnStart">
@@ -27,11 +27,11 @@
                         <md-icon md-font-set="material-icons">refresh</md-icon>
                         Sync With Trakt
                     </md-button>
-                </section>>
+                </section>
 
                 <section class="settings-select" ng-if="!app.Trakt.authenticated">
                     Connect to Trakt.tv to automatically 'scrobble' episodes you watch
-                </section>>
+                </section>
 
                 <section class="settings-select">
                     <md-button ng-click="connectTrakt()">
@@ -39,7 +39,7 @@
                         Connect To Trakt
                     </md-button>
                     <div class="loading-spinner" style="display: none"></div>
-                </section>>
+                </section>
         </div>
     </div>
-</section>>
+</section>

--- a/src/coffee/settings/templates/settings-tvshowtime.html
+++ b/src/coffee/settings/templates/settings-tvshowtime.html
@@ -16,7 +16,7 @@
        </section>
 
        <section class="settings-select" ng-if="!app.TVShowTime.authenticated">
-          <md-button ng-click="connectTrakt()">
+          <md-button class="md-raised md-accent" ng-click="connectTrakt()">
               <md-icon md-font-set="material-icons">user</md-icon>
               Connect To TVShow Time
           </md-button>

--- a/src/coffee/settings/templates/settings-userui.html
+++ b/src/coffee/settings/templates/settings-userui.html
@@ -44,10 +44,12 @@
         </md-input-container>
 
         <md-input-container ng-if="settings.config.showAdvancedSettings">
-            <label>Watched Items</label>
-            <md-select class="settings-dropdown" aria-label="watched-items" ng-model="settings.config.watch_type">
-               <md-option ng-repeat="type in settings.watch_types" name="watchedCovers">{{ type }}</md-option>
-            </md-select>
+            <section class="settings-select">
+                <div class="select-label">Watched Items</div>
+                <md-select class="settings-dropdown" aria-label="watched-items" ng-model="settings.config.watch_type">
+                <md-option ng-repeat="type in settings.watch_types" name="watchedCovers">{{ type }}</md-option>
+                </md-select>
+            </section>
         </md-input-container>
 
     </div>


### PR DESCRIPTION
Made similar items consistent with each other.
- Labels for drop down list are now all on top (no longer mixed for over and under)
- Checkboxes now have their labels next to them (no longer under)
- All button now have the same accent
