### PR TITLE
use minWidth instead of depreciated min-Width

### DIFF
--- a/src/scripts/app-window.coffee
+++ b/src/scripts/app-window.coffee
@@ -12,8 +12,8 @@ class AppWindow extends EventEmitter
 
     defaults =
       title: 'Butter'
-      'min-width': 520
-      'min-height': 520
+      'minWidth': 520
+      'minHeight': 520
       frame: false
       resizable: true
       show: false


### PR DESCRIPTION
![screen shot 2016-04-03 at 12 14 17 am](https://cloud.githubusercontent.com/assets/11602629/14231306/ea0faf20-f932-11e5-95dc-9d1ff11ed5f4.png)
In the Build Logs
